### PR TITLE
Add TDD sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # `fluid`
 
 The [official PaddlePaddle implementation](https://github.com/PaddlePaddle/Paddle/tree/develop/paddle/fluid) looks somehow deviated from [my original design](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/fluid/design/motivation/fluid.md).  When I review the lessons I learned from this project, I feel that we should have a minimum-viable-product (MVP) first to demo the design purpose and to help contributors better understand the design before they start coding.  Thereforce, I am working on this experimental, simplified re-implementation of PaddlePaddle Fluid.
+
+To get quick start, please read and run `python/fluid/tests/fit_a_line.py`.

--- a/python/fluid/tests/fit_a_line.py
+++ b/python/fluid/tests/fit_a_line.py
@@ -1,0 +1,22 @@
+# Usage:
+#
+#  1. Compile the program into the intermediate representation (IR):
+#
+#     python fit_a_line.py
+#
+#  2. Interpret and run the IR:
+#
+#     python fit_a_line.py | fluid
+#
+#     where fluid is the Fluid interpreter, a C++ program.
+#
+import fluid
+
+W = fluid.Tensor(1.0)
+
+with fluid.loop(steps=100):
+    x, y = fluid.data()
+    cost = fluid.mse(fluid.fc(x, W), y)
+    fluid.optimize(cost)
+
+fluid.print(W)


### PR DESCRIPTION
In order to make the development of this repo going straight ahead, I am trying the test-driven development -- (1) merge a simple Fluid program, which doesn't work at the right moment of course, and (2) make it work.

To make this simple TDD program, we need to 

1. have an intermediate representation (IR) definition: https://github.com/wangkuiyi/fluid/issues/3,
1. define the Python `fluid` package so that the execution of this TDD program generates a valid IR,
1. write the Fluid interpreter to run the program in its IR.